### PR TITLE
Remove height constraint from menus

### DIFF
--- a/src/common/components/MultiSelect.tsx
+++ b/src/common/components/MultiSelect.tsx
@@ -12,9 +12,6 @@ import InputLabel from '@material-ui/core/InputLabel';
 import { MenuItem, MenuItemGroup, MenuItemValue } from 'common/types';
 
 const useStyles = makeStyles((_theme) => ({
-  menu: {
-    maxHeight: '40%',
-  },
   loading: {
     display: 'grid',
     justifyItems: 'center',
@@ -87,7 +84,6 @@ export default function MultiSelect<T extends MenuItemValue>({
         renderValue={(value: unknown) => renderValues(value as T[])}
         // Prevents menu from scrolling upon selection and constrains height.
         MenuProps={{
-          classes: { paper: classes.menu },
           anchorOrigin: {
             vertical: 'bottom',
             horizontal: 'left',

--- a/src/common/components/SingleSelect.tsx
+++ b/src/common/components/SingleSelect.tsx
@@ -9,9 +9,6 @@ import InputLabel from '@material-ui/core/InputLabel';
 import { MenuItem, MenuItemValue } from 'common/types';
 
 const useStyles = makeStyles((_theme) => ({
-  menu: {
-    maxHeight: '40%',
-  },
   loading: {
     display: 'grid',
     justifyItems: 'center',
@@ -62,11 +59,7 @@ export default function SingleSelect<T extends MenuItemValue>({
   return (
     <FormControl className={className}>
       {label && <InputLabel>{label}</InputLabel>}
-      <Select
-        value={selectedValue}
-        onChange={handleChange}
-        MenuProps={{ classes: { paper: classes.menu } }}
-      >
+      <Select value={selectedValue} onChange={handleChange}>
         {loading ? (
           <div className={classes.loading}>
             <CircularProgress />


### PR DESCRIPTION
### Description

Remove height constraint from menus, allowing menus to occupy nearly the full viewport height.

### Checklist

- [ ] PR resolves ticket
- [ ] Changes have been tested locally
- [ ] No JavaScript errors in console

---
